### PR TITLE
Fix a bug where removing a feature here does remove from rollout

### DIFF
--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -14,10 +14,15 @@ module RolloutUi
     end
 
     def add_feature(feature)
+      unless rollout.features.include? feature.to_sym
+        rollout.activate_percentage(feature, 0)
+      end
+
       redis.sadd(:features, feature)
     end
 
     def remove_feature(feature)
+      rollout_delete(feature)
       redis.srem(:features, feature)
     end
 
@@ -28,6 +33,21 @@ module RolloutUi
 
     def redis
       rollout.instance_variable_get("@storage")
+    end
+
+    # rollout added a delete method in 2.2.1
+    # since we are using an older version inline the implementation here
+    def rollout_delete(feature)
+      # access rollout private methods
+      features_key = rollout.send(:features_key)
+      feature_key = rollout.send(:key, feature)
+
+      # inlined copy of implementation from rollout.delete
+      # https://github.com/FetLife/rollout/blob/master/lib/rollout.rb#L124
+      features = rollout.features
+      features.delete(feature)
+      redis.set(features_key, features.join(","))
+      redis.del(feature_key)
     end
   end
 end

--- a/spec/lib/rollout_ui/wrapper_spec.rb
+++ b/spec/lib/rollout_ui/wrapper_spec.rb
@@ -67,6 +67,7 @@ describe RolloutUi::Wrapper do
       @rollout_ui.add_feature(:featureA)
 
       @rollout_ui.features.should == ["featureA"]
+      @rollout_ui.rollout.features.should == [:featureA]
     end
   end
 
@@ -77,6 +78,7 @@ describe RolloutUi::Wrapper do
       @rollout_ui.remove_feature(:feature)
 
       @rollout_ui.features.should == []
+      @rollout_ui.rollout.features.should == []
     end
   end
 end


### PR DESCRIPTION
RolloutUI and Rollout use different redis calls for the feature list. `smembers` vs `get('feature:__features__')`.
The reason this works is rollout_ui monkey patches rollout to copy its data into smembers on init.

This commit enhances add/remove_feature to update the rollout store in addition to the rollout_ui replica.